### PR TITLE
feat(vite): 配置开发环境代理并调整请求基础 URL

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -11,4 +11,4 @@ VITE_WEB_ENV = 'development'
 VITE_WEB_BASE_API = '/dev-api'
 
 # 本地接口
-VITE_API_URL = *
+VITE_API_URL = http://localhost:6039

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -13,7 +13,7 @@ interface BaseResponse {
 }
 
 export const request = hookFetch.create<BaseResponse, 'data' | 'rows'>({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: import.meta.env.VITE_WEB_BASE_API,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,5 +23,17 @@ export default defineConfig((cnf) => {
         },
       },
     },
+    server: {
+      host: true,
+      proxy: {
+        // https://cn.vitejs.dev/config/#server-proxy
+        '/dev-api': {
+          target: env.VITE_API_URL,
+          changeOrigin: true,
+          ws: true,
+          rewrite: (path) => path.replace(/^\/dev-api/, '')
+        }
+      }
+    }
   };
 });


### PR DESCRIPTION
- 在 .env.development 文件中设置 VITE_API_URL 为 http://localhost:6039
- 在 src/utils/request.ts 中将请求的 baseURL 改为 VITE_WEB_BASE_API
- 在 vite.config.ts 中添加开发环境代理配置，将 /dev-api 代理到 VITE_API_URL